### PR TITLE
chore: latest timestamp get status

### DIFF
--- a/LDKNodeMonday/View/Home/BitcoinView.swift
+++ b/LDKNodeMonday/View/Home/BitcoinView.swift
@@ -59,21 +59,22 @@ struct BitcoinView: View {
                                 .lineLimit(1)
                                 .foregroundColor(.primary)
 
-                                let date = Date(
-                                    timeIntervalSince1970: TimeInterval(
-                                        viewModel.status?.latestOnchainWalletSyncTimestamp
-                                            ?? UInt64(0)
+                                if let status = viewModel.status,
+                                    let timestamp = status.latestOnchainWalletSyncTimestamp
+                                {
+                                    let date = Date(
+                                        timeIntervalSince1970: TimeInterval(
+                                            timestamp
+                                        )
                                     )
-                                )
-                                Text(date.formattedDate())
-                                    .lineLimit(1)
-                                    .font(.caption2)
-                                    .foregroundColor(.secondary)
-                                    .padding(.bottom, 20.0)
-                                    .minimumScaleFactor(0.5)
-                                    .redacted(
-                                        reason: viewModel.isStatusFinished ? [] : .placeholder
-                                    )
+                                    Text(date.formattedDate())
+                                        .lineLimit(1)
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                        .padding(.bottom, 20.0)
+                                        .minimumScaleFactor(0.5)
+                                }
+
                             }
 
                             VStack {
@@ -100,20 +101,21 @@ struct BitcoinView: View {
                                 .lineLimit(1)
                                 .foregroundColor(.primary)
 
-                                let date = Date(
-                                    timeIntervalSince1970: TimeInterval(
-                                        viewModel.status?.latestWalletSyncTimestamp ?? UInt64(0)
+                                if let status = viewModel.status,
+                                    let timestamp = status.latestOnchainWalletSyncTimestamp
+                                {
+                                    let date = Date(
+                                        timeIntervalSince1970: TimeInterval(
+                                            timestamp
+                                        )
                                     )
-                                )
-                                Text(date.formattedDate())
-                                    .lineLimit(1)
-                                    .font(.caption2)
-                                    .foregroundColor(.secondary)
-                                    .padding(.bottom, 20.0)
-                                    .minimumScaleFactor(0.5)
-                                    .redacted(
-                                        reason: viewModel.isStatusFinished ? [] : .placeholder
-                                    )
+                                    Text(date.formattedDate())
+                                        .lineLimit(1)
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                        .padding(.bottom, 20.0)
+                                        .minimumScaleFactor(0.5)
+                                }
                             }
 
                             HStack {


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Not sure what the best way to handle this is, but when calling `getStatus` `.onAppear` the values of latest timestamps are not available yet (`nil`), but then after a few seconds they are not `nil` anymore (like when a user might pull to refresh). I'm not sure the best way to handle it, I played around with a few animations, delaying `getStatus` call for 5 seconds, and none felt quite right for now.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I have formatted my code with [swift-format](https://github.com/apple/swift-format) per `.swift-format` [file](https://github.com/reez/BDKSwiftExampleWallet/blob/main/.swift-format)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
