### PR TITLE
UI: Tappable balance

### DIFF
--- a/LDKNodeMonday/App/LDKNodeMondayApp.swift
+++ b/LDKNodeMonday/App/LDKNodeMondayApp.swift
@@ -12,7 +12,7 @@ struct LDKNodeMondayApp: App {
 
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
-    @State private var walletClient = WalletClient(keyClient: .live)
+    @State private var walletClient = WalletClient(appMode: .live)
     @State private var navigationPath = NavigationPath()
 
     init() {

--- a/LDKNodeMonday/App/WalletClient.swift
+++ b/LDKNodeMonday/App/WalletClient.swift
@@ -19,9 +19,16 @@ public class WalletClient {
     public var appState = AppState.loading
     public var appError: Error?
 
-    public init(keyClient: KeyClient) {
-        self.keyClient = keyClient
-        self.lightningClient = .live
+    public init(appMode: AppMode) {
+        switch appMode {
+        case .live:
+            self.keyClient = .live
+            self.lightningClient = .live
+        case .mock:
+            self.keyClient = .mock
+            self.lightningClient = .mock
+        }
+
     }
 
     func createWallet(seedPhrase: String, network: Network, server: EsploraServer) async {
@@ -111,6 +118,11 @@ public class WalletClient {
             }
         }
     }
+}
+
+public enum AppMode {
+    case live
+    case mock
 }
 
 public enum AppState {

--- a/LDKNodeMonday/Service/Lightning Service/LightningNodeService.swift
+++ b/LDKNodeMonday/Service/Lightning Service/LightningNodeService.swift
@@ -173,6 +173,11 @@ class LightningNodeService {
         return address
     }
 
+    func balanceDetails() async -> BalanceDetails {
+        let balanceDetails = ldkNode.listBalances()
+        return balanceDetails
+    }
+
     func spendableOnchainBalanceSats() async -> UInt64 {
         let balance = ldkNode.listBalances().spendableOnchainBalanceSats
         return balance
@@ -337,6 +342,7 @@ public struct LightningNodeClient {
     let reset: () throws -> Void
     let nodeId: () -> String
     let newAddress: () async throws -> String
+    let balanceDetails: () async -> BalanceDetails
     let spendableOnchainBalanceSats: () async -> UInt64
     let totalOnchainBalanceSats: () async -> UInt64
     let totalLightningBalanceSats: () async -> UInt64
@@ -371,6 +377,7 @@ extension LightningNodeClient {
         reset: { try LightningNodeService.shared.reset() },
         nodeId: { LightningNodeService.shared.nodeId() },
         newAddress: { try await LightningNodeService.shared.newAddress() },
+        balanceDetails: { await LightningNodeService.shared.balanceDetails() },
         spendableOnchainBalanceSats: {
             await LightningNodeService.shared.spendableOnchainBalanceSats()
         },
@@ -436,61 +443,114 @@ extension LightningNodeClient {
     )
 }
 
-#if DEBUG
-    extension LightningNodeClient {
-        static let mock = Self(
-            start: {},
-            stop: {},
-            restart: {},
-            reset: {},
-            nodeId: { "038474837483784378437843784378437843784378" },
-            newAddress: { "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx" },
-            spendableOnchainBalanceSats: { 100_000 },
-            totalOnchainBalanceSats: { 150_000 },
-            totalLightningBalanceSats: { 50_000 },
-            lightningBalances: { [] },
-            pendingBalancesFromChannelClosures: { [] },
-            connect: { _, _, _ in },
-            disconnect: { _ in },
-            connectOpenChannel: { _, _, _, _, _, _ in UserChannelId("abcdef") },
-            closeChannel: { _, _ in },
-            send: { _ in QrPaymentResult.onchain(txid: "txid") },
-            receive: { _, _, _ in "lightning:lnbc1..." },
-            receiveViaJitChannel: { _, _, _, _ in Bolt11Invoice("lnbc1...") },
-            listPeers: { [] },
-            listChannels: { [] },
-            listPayments: { [] },
-            status: {
-                NodeStatus(
-                    isRunning: true,
-                    isListening: true,
-                    currentBestBlock: BestBlock(
-                        blockHash: BlockHash(
-                            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
-                        ),
-                        height: 123456
+extension LightningNodeClient {
+    static let mock = Self(
+        start: {},
+        stop: {},
+        restart: {},
+        reset: {},
+        nodeId: { "038474837483784378437843784378437843784378" },
+        newAddress: { "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx" },
+        balanceDetails: { .mock },
+        spendableOnchainBalanceSats: { 100_000 },
+        totalOnchainBalanceSats: { 150_000 },
+        totalLightningBalanceSats: { 50_000 },
+        lightningBalances: { [] },
+        pendingBalancesFromChannelClosures: { [] },
+        connect: { _, _, _ in },
+        disconnect: { _ in },
+        connectOpenChannel: { _, _, _, _, _, _ in UserChannelId("abcdef") },
+        closeChannel: { _, _ in },
+        send: { _ in QrPaymentResult.onchain(txid: "txid") },
+        receive: { _, _, _ in "lightning:lnbc1..." },
+        receiveViaJitChannel: { _, _, _, _ in Bolt11Invoice("lnbc1...") },
+        listPeers: { [] },
+        listChannels: { [] },
+        listPayments: { mockPayments },
+        status: {
+            NodeStatus(
+                isRunning: true,
+                isListening: true,
+                currentBestBlock: BestBlock(
+                    blockHash: BlockHash(
+                        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
                     ),
-                    latestLightningWalletSyncTimestamp: UInt64(Date().timeIntervalSince1970),
-                    latestOnchainWalletSyncTimestamp: UInt64(Date().timeIntervalSince1970),
-                    latestFeeRateCacheUpdateTimestamp: UInt64(Date().timeIntervalSince1970),
-                    latestRgsSnapshotTimestamp: UInt64(Date().timeIntervalSince1970),
-                    latestNodeAnnouncementBroadcastTimestamp: UInt64(Date().timeIntervalSince1970),
-                    latestChannelMonitorArchivalHeight: 123456
-                )
-            },
-            deleteWallet: {},
-            getBackupInfo: {
-                BackupInfo(
-                    mnemonic: "test test test",
-                    networkString: Network.signet.description,
-                    serverURL: EsploraServer.mutiny_signet.url
-                )
-            },
-            deleteDocuments: {},
-            getNetwork: { .signet },
-            getServer: { .mutiny_signet },
-            getNetworkColor: { .orange },
-            listenForEvents: {}
-        )
-    }
-#endif
+                    height: 123456
+                ),
+                latestLightningWalletSyncTimestamp: UInt64(Date().timeIntervalSince1970),
+                latestOnchainWalletSyncTimestamp: UInt64(Date().timeIntervalSince1970),
+                latestFeeRateCacheUpdateTimestamp: UInt64(Date().timeIntervalSince1970),
+                latestRgsSnapshotTimestamp: UInt64(Date().timeIntervalSince1970),
+                latestNodeAnnouncementBroadcastTimestamp: UInt64(Date().timeIntervalSince1970),
+                latestChannelMonitorArchivalHeight: 123456
+            )
+        },
+        deleteWallet: {},
+        getBackupInfo: {
+            BackupInfo(
+                mnemonic: "test test test",
+                networkString: Network.signet.description,
+                serverURL: EsploraServer.mutiny_signet.url
+            )
+        },
+        deleteDocuments: {},
+        getNetwork: { .signet },
+        getServer: { .mutiny_signet },
+        getNetworkColor: { .orange },
+        listenForEvents: {}
+    )
+}
+
+let mockPayments: [PaymentDetails] = [
+    .init(
+        id: "1",
+        kind: .bolt11(hash: "hash1", preimage: nil, secret: nil),
+        amountMsat: 100_000_000,
+        direction: .inbound,
+        status: .succeeded,
+        latestUpdateTimestamp: 1_718_841_600
+    ),
+    .init(
+        id: "4",
+        kind: .bolt11(hash: "hash3", preimage: nil, secret: nil),
+        amountMsat: 210_000_000,
+        direction: .outbound,
+        status: .succeeded,
+        latestUpdateTimestamp: 1_718_841_640
+    ),
+    .init(
+        id: "2",
+        kind: .bolt11(hash: "hash2", preimage: nil, secret: nil),
+        amountMsat: 100_000_000,
+        direction: .inbound,
+        status: .pending,
+        latestUpdateTimestamp: 1_718_841_620
+    ),
+    .init(
+        id: "3",
+        kind: .bolt11(hash: "hash3", preimage: nil, secret: nil),
+        amountMsat: 100_000_000,
+        direction: .inbound,
+        status: .failed,
+        latestUpdateTimestamp: 1_718_841_630
+    ),
+]
+
+extension BalanceDetails {
+    static let empty = BalanceDetails(
+        totalOnchainBalanceSats: 0,
+        spendableOnchainBalanceSats: 0,
+        totalAnchorChannelsReserveSats: 0,
+        totalLightningBalanceSats: 0,
+        lightningBalances: [],
+        pendingBalancesFromChannelClosures: []
+    )
+    static let mock = BalanceDetails(
+        totalOnchainBalanceSats: 150000,
+        spendableOnchainBalanceSats: 100000,
+        totalAnchorChannelsReserveSats: 0,
+        totalLightningBalanceSats: 50000,
+        lightningBalances: [],
+        pendingBalancesFromChannelClosures: []
+    )
+}

--- a/LDKNodeMonday/Service/Lightning Service/LightningNodeService.swift
+++ b/LDKNodeMonday/Service/Lightning Service/LightningNodeService.swift
@@ -173,9 +173,9 @@ class LightningNodeService {
         return address
     }
 
-    func balanceDetails() async -> BalanceDetails {
-        let balanceDetails = ldkNode.listBalances()
-        return balanceDetails
+    func listBalances() async -> BalanceDetails {
+        let balances = ldkNode.listBalances()
+        return balances
     }
 
     func spendableOnchainBalanceSats() async -> UInt64 {
@@ -342,7 +342,7 @@ public struct LightningNodeClient {
     let reset: () throws -> Void
     let nodeId: () -> String
     let newAddress: () async throws -> String
-    let balanceDetails: () async -> BalanceDetails
+    let balances: () async -> BalanceDetails
     let spendableOnchainBalanceSats: () async -> UInt64
     let totalOnchainBalanceSats: () async -> UInt64
     let totalLightningBalanceSats: () async -> UInt64
@@ -377,7 +377,7 @@ extension LightningNodeClient {
         reset: { try LightningNodeService.shared.reset() },
         nodeId: { LightningNodeService.shared.nodeId() },
         newAddress: { try await LightningNodeService.shared.newAddress() },
-        balanceDetails: { await LightningNodeService.shared.balanceDetails() },
+        balances: { await LightningNodeService.shared.listBalances() },
         spendableOnchainBalanceSats: {
             await LightningNodeService.shared.spendableOnchainBalanceSats()
         },
@@ -451,7 +451,7 @@ extension LightningNodeClient {
         reset: {},
         nodeId: { "038474837483784378437843784378437843784378" },
         newAddress: { "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx" },
-        balanceDetails: { .mock },
+        balances: { .mock },
         spendableOnchainBalanceSats: { 100_000 },
         totalOnchainBalanceSats: { 150_000 },
         totalLightningBalanceSats: { 50_000 },

--- a/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
+++ b/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
@@ -48,7 +48,7 @@ class BitcoinViewModel: ObservableObject {
 
     func getStatus() async {
         let status = lightningClient.status()
-        let sCopy = status
+        let sCopy = status // To avoid issues with non-sendable object
         await MainActor.run {
             self.status = sCopy
             self.isStatusFinished = true
@@ -58,7 +58,6 @@ class BitcoinViewModel: ObservableObject {
     func getBalanceDetails() async {
         let balanceDetails = await lightningClient.balanceDetails()
         let bdCopy = balanceDetails  // To avoid issues with non-sendable object
-
         await MainActor.run {
             self.balanceDetails = bdCopy
             self.unifiedBalance =

--- a/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
+++ b/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
@@ -24,11 +24,6 @@ class BitcoinViewModel: ObservableObject {
     var price: Double = 0.00
     var time: Int?
 
-    var satsPrice: String { // TODO: Not sure how this is being used / if correct?
-        let usdValue = Double(unifiedBalance).valueInUSD(price: price)
-        return usdValue
-    }
-
     var totalUSDValue: String {
         let totalUSD = Double(unifiedBalance).valueInUSD(price: price)
         return totalUSD

--- a/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
+++ b/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
@@ -38,7 +38,14 @@ class BitcoinViewModel: ObservableObject {
         self.priceClient = priceClient
         self.lightningClient = lightningClient
     }
-
+    
+    func update() async {
+        await getBalanceDetails()
+        await getPrices()
+        await getStatus()
+        getColor()
+    }
+    
     func getStatus() async {
         let status = lightningClient.status()
         let sCopy = status

--- a/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
+++ b/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
@@ -14,13 +14,9 @@ class BitcoinViewModel: ObservableObject {
     @Published var networkColor = Color.gray
     @Published var status: NodeStatus?
     @Published var isStatusFinished: Bool = false
-    @Published var spendableBalance: UInt64 = 0
-    @Published var totalBalance: UInt64 = 0
-    @Published var totalLightningBalance: UInt64 = 0
-    @Published var lightningBalances: [LightningBalance] = []
-    @Published var isSpendableBalanceFinished: Bool = false
-    @Published var isTotalBalanceFinished: Bool = false
-    @Published var isTotalLightningBalanceFinished: Bool = false
+    @Published var balanceDetails: BalanceDetails = .empty
+    @Published var unifiedBalance: UInt64 = 0
+    @Published var isBalanceDetailsFinished: Bool = false
     @Published var isPriceFinished: Bool = false
 
     let lightningClient: LightningNodeClient
@@ -28,13 +24,13 @@ class BitcoinViewModel: ObservableObject {
     var price: Double = 0.00
     var time: Int?
 
-    var satsPrice: String {
-        let usdValue = Double(totalBalance).valueInUSD(price: price)
+    var satsPrice: String { // TODO: Not sure how this is being used / if correct?
+        let usdValue = Double(unifiedBalance).valueInUSD(price: price)
         return usdValue
     }
 
     var totalUSDValue: String {
-        let totalUSD = Double(totalBalance + totalLightningBalance).valueInUSD(price: price)
+        let totalUSD = Double(unifiedBalance).valueInUSD(price: price)
         return totalUSD
     }
 
@@ -56,27 +52,15 @@ class BitcoinViewModel: ObservableObject {
         }
     }
 
-    func getTotalOnchainBalanceSats() async {
-        let balance = await lightningClient.totalOnchainBalanceSats()
-        DispatchQueue.main.async {
-            self.totalBalance = balance
-            self.isTotalBalanceFinished = true
-        }
-    }
+    func getBalanceDetails() async {
+        let balanceDetails = await lightningClient.balanceDetails()
+        let bdCopy = balanceDetails  // To avoid issues with non-sendable object
 
-    func getSpendableOnchainBalanceSats() async {
-        let balance = await lightningClient.spendableOnchainBalanceSats()
-        DispatchQueue.main.async {
-            self.spendableBalance = balance
-            self.isSpendableBalanceFinished = true
-        }
-    }
-
-    func getTotalLightningBalanceSats() async {
-        let balance = await lightningClient.totalLightningBalanceSats()
-        DispatchQueue.main.async {
-            self.totalLightningBalance = balance
-            self.isTotalLightningBalanceFinished = true
+        await MainActor.run {
+            self.balanceDetails = bdCopy
+            self.unifiedBalance =
+                balanceDetails.totalOnchainBalanceSats + balanceDetails.totalLightningBalanceSats
+            self.isBalanceDetailsFinished = true
         }
     }
 

--- a/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
+++ b/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
@@ -14,9 +14,9 @@ class BitcoinViewModel: ObservableObject {
     @Published var networkColor = Color.gray
     @Published var status: NodeStatus?
     @Published var isStatusFinished: Bool = false
-    @Published var balanceDetails: BalanceDetails = .empty
+    @Published var balances: BalanceDetails = .empty
     @Published var unifiedBalance: UInt64 = 0
-    @Published var isBalanceDetailsFinished: Bool = false
+    @Published var isBalancesFinished: Bool = false
     @Published var isPriceFinished: Bool = false
 
     let lightningClient: LightningNodeClient
@@ -40,7 +40,7 @@ class BitcoinViewModel: ObservableObject {
     }
 
     func update() async {
-        await getBalanceDetails()
+        await getBalances()
         await getPrices()
         await getStatus()
         getColor()
@@ -55,14 +55,14 @@ class BitcoinViewModel: ObservableObject {
         }
     }
 
-    func getBalanceDetails() async {
-        let balanceDetails = await lightningClient.balanceDetails()
-        let bdCopy = balanceDetails  // To avoid issues with non-sendable object
+    func getBalances() async {
+        let balances = await lightningClient.balances()
+        let bdCopy = balances  // To avoid issues with non-sendable object
         await MainActor.run {
-            self.balanceDetails = bdCopy
+            self.balances = bdCopy
             self.unifiedBalance =
-                balanceDetails.totalOnchainBalanceSats + balanceDetails.totalLightningBalanceSats
-            self.isBalanceDetailsFinished = true
+                balances.totalOnchainBalanceSats + balances.totalLightningBalanceSats
+            self.isBalancesFinished = true
         }
     }
 

--- a/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
+++ b/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
@@ -41,8 +41,9 @@ class BitcoinViewModel: ObservableObject {
 
     func getStatus() async {
         let status = lightningClient.status()
-        DispatchQueue.main.async {
-            self.status = status
+        let sCopy = status
+        await MainActor.run {
+            self.status = sCopy
             self.isStatusFinished = true
         }
     }
@@ -62,18 +63,18 @@ class BitcoinViewModel: ObservableObject {
     func getPrices() async {
         do {
             let price = try await priceClient.fetchPrice()
-            DispatchQueue.main.async {
+            await MainActor.run {
                 self.price = price.usd
                 self.time = price.time
                 self.isPriceFinished = true
             }
         } catch let error as NodeError {
             let errorString = handleNodeError(error)
-            DispatchQueue.main.async {
+            await MainActor.run {
                 self.bitcoinViewError = .init(title: errorString.title, detail: errorString.detail)
             }
         } catch {
-            DispatchQueue.main.async {
+            await MainActor.run {
                 self.bitcoinViewError = .init(
                     title: "Unexpected error",
                     detail: error.localizedDescription

--- a/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
+++ b/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
@@ -48,7 +48,7 @@ class BitcoinViewModel: ObservableObject {
 
     func getStatus() async {
         let status = lightningClient.status()
-        let sCopy = status // To avoid issues with non-sendable object
+        let sCopy = status  // To avoid issues with non-sendable object
         await MainActor.run {
             self.status = sCopy
             self.isStatusFinished = true

--- a/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
+++ b/LDKNodeMonday/View Model/Home/BitcoinViewModel.swift
@@ -38,14 +38,14 @@ class BitcoinViewModel: ObservableObject {
         self.priceClient = priceClient
         self.lightningClient = lightningClient
     }
-    
+
     func update() async {
         await getBalanceDetails()
         await getPrices()
         await getStatus()
         getColor()
     }
-    
+
     func getStatus() async {
         let status = lightningClient.status()
         let sCopy = status

--- a/LDKNodeMonday/View/Home/BitcoinView.swift
+++ b/LDKNodeMonday/View/Home/BitcoinView.swift
@@ -259,11 +259,13 @@ struct BalanceHeader: View {
 
     var balanceValue: String {
         switch displayBalanceType {
-        case .unifiedFiat:
+        case .fiatBtc:
             return viewModel.totalUSDValue
-        case .unifiedBTC:
+        case .fiatSats:
+            return viewModel.totalUSDValue
+        case .btcFiat:
             return "₿" + viewModel.unifiedBalance.formattedSatoshis()
-        case .unifiedSats:
+        case .totalSats:
             return viewModel.unifiedBalance.formatted(.number.notation(.automatic))
         case .onchainSats:
             return viewModel.balanceDetails.totalOnchainBalanceSats.formatted(
@@ -278,11 +280,13 @@ struct BalanceHeader: View {
 
     var secondaryValue: String {
         switch displayBalanceType {
-        case .unifiedFiat:
+        case .fiatBtc:
             return "₿" + viewModel.unifiedBalance.formattedSatoshis()
-        case .unifiedBTC:
+        case .fiatSats:
+            return viewModel.unifiedBalance.formatted(.number.notation(.automatic))
+        case .btcFiat:
             return viewModel.totalUSDValue
-        case .unifiedSats:
+        case .totalSats:
             return "Total"
         case .onchainSats:
             return "Onchain"
@@ -293,11 +297,13 @@ struct BalanceHeader: View {
 
     var unitValue: String {
         switch displayBalanceType {
-        case .unifiedFiat:
+        case .fiatBtc:
             return ""
-        case .unifiedBTC:
+        case .fiatSats:
+            return "Sats"
+        case .btcFiat:
             return ""
-        case .unifiedSats:
+        case .totalSats:
             return "Sats"
         case .onchainSats:
             return "Sats"
@@ -313,9 +319,10 @@ enum NavigationDestination: Hashable {
 }
 
 public enum DisplayBalanceType: String {
-    case unifiedFiat
-    case unifiedBTC
-    case unifiedSats
+    case fiatBtc
+    case fiatSats
+    case btcFiat
+    case totalSats
     case onchainSats
     case lightningSats
 }
@@ -323,24 +330,26 @@ public enum DisplayBalanceType: String {
 extension DisplayBalanceType {
     mutating func next() {
         switch self {
-        case .unifiedFiat:
-            self = .unifiedBTC
-        case .unifiedBTC:
-            self = .unifiedSats
-        case .unifiedSats:
+        case .fiatBtc:
+            self = .fiatSats
+        case .fiatSats:
+            self = .btcFiat
+        case .btcFiat:
+            self = .totalSats
+        case .totalSats:
             self = .onchainSats
         case .onchainSats:
             self = .lightningSats
         case .lightningSats:
-            self = .unifiedFiat
+            self = .fiatBtc
         }
     }
 
     static let userDefaults: DisplayBalanceType =
         DisplayBalanceType(
             rawValue: UserDefaults.standard.string(forKey: "displayBalanceType")
-                ?? DisplayBalanceType.unifiedFiat.rawValue
-        ) ?? DisplayBalanceType.unifiedFiat
+                ?? DisplayBalanceType.fiatBtc.rawValue
+        ) ?? DisplayBalanceType.fiatBtc
 }
 
 #if DEBUG

--- a/LDKNodeMonday/View/Home/BitcoinView.swift
+++ b/LDKNodeMonday/View/Home/BitcoinView.swift
@@ -202,7 +202,7 @@ struct BitcoinView: View {
             case .address:
                 AddressView(
                     navigationPath: $sendNavigationPath,
-                    spendableBalance: viewModel.balanceDetails.spendableOnchainBalanceSats
+                    spendableBalance: viewModel.balances.spendableOnchainBalanceSats
                 )
             case .amount(let address, let amount, let payment):
                 AmountView(
@@ -210,7 +210,7 @@ struct BitcoinView: View {
                     address: address,
                     numpadAmount: amount,
                     payment: payment,
-                    spendableBalance: viewModel.balanceDetails.spendableOnchainBalanceSats,
+                    spendableBalance: viewModel.balances.spendableOnchainBalanceSats,
                     navigationPath: $sendNavigationPath
                 )
                 .onDisappear {
@@ -269,11 +269,11 @@ struct BalanceHeader: View {
         case .totalSats:
             return viewModel.unifiedBalance.formatted(.number.notation(.automatic))
         case .onchainSats:
-            return viewModel.balanceDetails.totalOnchainBalanceSats.formatted(
+            return viewModel.balances.totalOnchainBalanceSats.formatted(
                 .number.notation(.automatic)
             )
         case .lightningSats:
-            return viewModel.balanceDetails.totalLightningBalanceSats.formatted(
+            return viewModel.balances.totalLightningBalanceSats.formatted(
                 .number.notation(.automatic)
             )
         }

--- a/LDKNodeMonday/View/Home/BitcoinView.swift
+++ b/LDKNodeMonday/View/Home/BitcoinView.swift
@@ -343,14 +343,6 @@ extension DisplayBalanceType {
         ) ?? DisplayBalanceType.unifiedFiat
 }
 
-class SharedNamespace: ObservableObject {
-    let animation: Namespace.ID
-
-    init(namespace: Namespace.ID) {
-        self.animation = namespace
-    }
-}
-
 #if DEBUG
     #Preview {
         BitcoinView(

--- a/LDKNodeMonday/View/Home/BitcoinView.swift
+++ b/LDKNodeMonday/View/Home/BitcoinView.swift
@@ -101,6 +101,7 @@ struct BitcoinView: View {
                     }
                 }
             }
+            .dynamicTypeSize(...DynamicTypeSize.accessibility2)  // Sets max dynamic size for all Text
             .onAppear {
                 Task {
                     await viewModel.update()

--- a/LDKNodeMonday/View/Home/BitcoinView.swift
+++ b/LDKNodeMonday/View/Home/BitcoinView.swift
@@ -300,15 +300,15 @@ struct BalanceHeader: View {
         case .fiatBtc:
             return ""
         case .fiatSats:
-            return "Sats"
+            return "sats"
         case .btcFiat:
             return ""
         case .totalSats:
-            return "Sats"
+            return "sats"
         case .onchainSats:
-            return "Sats"
+            return "sats"
         case .lightningSats:
-            return "Sats"
+            return "sats"
         }
     }
 }

--- a/LDKNodeMonday/View/Home/BitcoinView.swift
+++ b/LDKNodeMonday/View/Home/BitcoinView.swift
@@ -249,6 +249,7 @@ struct BalanceHeader: View {
             .font(.system(.headline, design: .rounded, weight: .medium))
         }
         .animation(.spring(), value: viewModel.isPriceFinished)
+        .sensoryFeedback(.increase, trigger: displayBalanceType)
         .onTapGesture {
             withAnimation {
                 displayBalanceType.next()

--- a/LDKNodeMonday/View/Home/BitcoinView.swift
+++ b/LDKNodeMonday/View/Home/BitcoinView.swift
@@ -259,9 +259,9 @@ struct BalanceHeader: View {
 
     var balanceValue: String {
         switch displayBalanceType {
-        case .fiatBtc:
-            return viewModel.totalUSDValue
         case .fiatSats:
+            return viewModel.totalUSDValue
+        case .fiatBtc:
             return viewModel.totalUSDValue
         case .btcFiat:
             return "₿" + viewModel.unifiedBalance.formattedSatoshis()
@@ -280,10 +280,10 @@ struct BalanceHeader: View {
 
     var secondaryValue: String {
         switch displayBalanceType {
-        case .fiatBtc:
-            return "₿" + viewModel.unifiedBalance.formattedSatoshis()
         case .fiatSats:
             return viewModel.unifiedBalance.formatted(.number.notation(.automatic))
+        case .fiatBtc:
+            return "₿" + viewModel.unifiedBalance.formattedSatoshis()
         case .btcFiat:
             return viewModel.totalUSDValue
         case .totalSats:
@@ -299,15 +299,9 @@ struct BalanceHeader: View {
         switch displayBalanceType {
         case .fiatBtc:
             return ""
-        case .fiatSats:
-            return "sats"
         case .btcFiat:
             return ""
-        case .totalSats:
-            return "sats"
-        case .onchainSats:
-            return "sats"
-        case .lightningSats:
+        default:
             return "sats"
         }
     }
@@ -319,8 +313,8 @@ enum NavigationDestination: Hashable {
 }
 
 public enum DisplayBalanceType: String {
-    case fiatBtc
     case fiatSats
+    case fiatBtc
     case btcFiat
     case totalSats
     case onchainSats
@@ -330,9 +324,9 @@ public enum DisplayBalanceType: String {
 extension DisplayBalanceType {
     mutating func next() {
         switch self {
-        case .fiatBtc:
-            self = .fiatSats
         case .fiatSats:
+            self = .fiatBtc
+        case .fiatBtc:
             self = .btcFiat
         case .btcFiat:
             self = .totalSats
@@ -341,7 +335,7 @@ extension DisplayBalanceType {
         case .onchainSats:
             self = .lightningSats
         case .lightningSats:
-            self = .fiatBtc
+            self = .fiatSats
         }
     }
 

--- a/LDKNodeMonday/View/Home/BitcoinView.swift
+++ b/LDKNodeMonday/View/Home/BitcoinView.swift
@@ -40,13 +40,13 @@ struct BitcoinView: View {
                                 Image(systemName: "bitcoinsign")
                                     .font(.title)
                                     .fontWeight(.thin)
-                                Text(viewModel.totalBalance.formattedSatoshis())
+                                Text(viewModel.unifiedBalance.formattedSatoshis())
                                     .contentTransition(.numericText())
                                     .font(.largeTitle)
                                     .fontWeight(.semibold)
                                     .fontDesign(.rounded)
                                     .redacted(
-                                        reason: viewModel.isTotalBalanceFinished
+                                        reason: viewModel.isBalanceDetailsFinished
                                             ? [] : .placeholder
                                     )
                                 Text("sats")
@@ -82,15 +82,18 @@ struct BitcoinView: View {
                                 Image(systemName: "bolt")
                                     .font(.title)
                                     .fontWeight(.thin)
-                                Text(viewModel.totalLightningBalance.formattedSatoshis())
-                                    .contentTransition(.numericText())
-                                    .font(.largeTitle)
-                                    .fontWeight(.semibold)
-                                    .fontDesign(.rounded)
-                                    .redacted(
-                                        reason: viewModel.isTotalLightningBalanceFinished
-                                            ? [] : .placeholder
-                                    )
+                                Text(
+                                    viewModel.balanceDetails.totalLightningBalanceSats
+                                        .formattedSatoshis()
+                                )
+                                .contentTransition(.numericText())
+                                .font(.largeTitle)
+                                .fontWeight(.semibold)
+                                .fontDesign(.rounded)
+                                .redacted(
+                                    reason: viewModel.isBalanceDetailsFinished
+                                        ? [] : .placeholder
+                                )
                                 Text("sats")
                                     .font(.title)
                                     .fontWeight(.thin)
@@ -141,10 +144,8 @@ struct BitcoinView: View {
                 .padding(.top, 220.0)
                 .padding(.horizontal, -20)
                 .refreshable {
-                    await viewModel.getTotalOnchainBalanceSats()
-                    await viewModel.getTotalLightningBalanceSats()
+                    await viewModel.getBalanceDetails()
                     await viewModel.getPrices()
-                    await viewModel.getSpendableOnchainBalanceSats()
                     await viewModel.getStatus()
                 }
 
@@ -211,11 +212,9 @@ struct BitcoinView: View {
             }
             .onAppear {
                 Task {
-                    await viewModel.getTotalOnchainBalanceSats()
-                    await viewModel.getTotalLightningBalanceSats()
+                    await viewModel.getBalanceDetails()
                     await viewModel.getPrices()
                     viewModel.getColor()
-                    await viewModel.getSpendableOnchainBalanceSats()
                     await viewModel.getStatus()
                 }
             }
@@ -232,10 +231,8 @@ struct BitcoinView: View {
             }
             .onReceive(eventService.$lastMessage) { _ in
                 Task {
-                    await viewModel.getTotalOnchainBalanceSats()
-                    await viewModel.getTotalLightningBalanceSats()
+                    await viewModel.getBalanceDetails()
                     await viewModel.getPrices()
-                    await viewModel.getSpendableOnchainBalanceSats()
                     await viewModel.getStatus()
                 }
             }
@@ -243,10 +240,8 @@ struct BitcoinView: View {
                 isPresented: $showingNodeIDView,
                 onDismiss: {
                     Task {
-                        await viewModel.getTotalOnchainBalanceSats()
-                        await viewModel.getTotalLightningBalanceSats()
+                        await viewModel.getBalanceDetails()
                         await viewModel.getPrices()
-                        await viewModel.getSpendableOnchainBalanceSats()
                         await viewModel.getStatus()
                     }
                 }
@@ -294,10 +289,8 @@ struct BitcoinView: View {
                 item: $showReceiveViewWithOption,
                 onDismiss: {
                     Task {
-                        await viewModel.getTotalOnchainBalanceSats()
-                        await viewModel.getTotalLightningBalanceSats()
+                        await viewModel.getBalanceDetails()
                         await viewModel.getPrices()
-                        await viewModel.getSpendableOnchainBalanceSats()
                         await viewModel.getStatus()
                     }
                 }
@@ -312,10 +305,8 @@ struct BitcoinView: View {
                 isPresented: $isPaymentsPresented,
                 onDismiss: {
                     Task {
-                        await viewModel.getTotalOnchainBalanceSats()
-                        await viewModel.getTotalLightningBalanceSats()
+                        await viewModel.getBalanceDetails()
                         await viewModel.getPrices()
-                        await viewModel.getSpendableOnchainBalanceSats()
                         await viewModel.getStatus()
                     }
                 }
@@ -330,7 +321,7 @@ struct BitcoinView: View {
             case .address:
                 AddressView(
                     navigationPath: $sendNavigationPath,
-                    spendableBalance: viewModel.spendableBalance
+                    spendableBalance: viewModel.balanceDetails.spendableOnchainBalanceSats
                 )
             case .amount(let address, let amount, let payment):
                 AmountView(
@@ -338,15 +329,13 @@ struct BitcoinView: View {
                     address: address,
                     numpadAmount: amount,
                     payment: payment,
-                    spendableBalance: viewModel.spendableBalance,
+                    spendableBalance: viewModel.balanceDetails.spendableOnchainBalanceSats,
                     navigationPath: $sendNavigationPath
                 )
                 .onDisappear {
                     Task {
-                        await viewModel.getTotalOnchainBalanceSats()
-                        await viewModel.getTotalLightningBalanceSats()
+                        await viewModel.getBalanceDetails()
                         await viewModel.getPrices()
-                        await viewModel.getSpendableOnchainBalanceSats()
                         await viewModel.getStatus()
                     }
                 }

--- a/LDKNodeMonday/View/Home/BitcoinView.swift
+++ b/LDKNodeMonday/View/Home/BitcoinView.swift
@@ -368,7 +368,7 @@ enum NavigationDestination: Hashable {
     #Preview {
         BitcoinView(
             viewModel: .init(
-                walletClient: .constant(WalletClient(keyClient: KeyClient.mock)),
+                walletClient: .constant(WalletClient(appMode: AppMode.mock)),
                 priceClient: .mock,
                 lightningClient: .mock
             ),

--- a/LDKNodeMonday/View/Home/NetworkSettingsView.swift
+++ b/LDKNodeMonday/View/Home/NetworkSettingsView.swift
@@ -128,6 +128,6 @@ struct NetworkSettingsView: View {
 
 #if DEBUG
     #Preview {
-        NetworkSettingsView(walletClient: .constant(WalletClient(keyClient: KeyClient.mock)))
+        NetworkSettingsView(walletClient: .constant(WalletClient(appMode: AppMode.mock)))
     }
 #endif

--- a/LDKNodeMonday/View/Home/OnboardingView.swift
+++ b/LDKNodeMonday/View/Home/OnboardingView.swift
@@ -138,7 +138,7 @@ struct OnboardingView: View {
     #Preview {
         OnboardingView(
             viewModel: .init(
-                walletClient: .constant(WalletClient(keyClient: KeyClient.mock))
+                walletClient: .constant(WalletClient(appMode: AppMode.mock))
             )
         )
     }

--- a/LDKNodeMonday/View/Settings/SettingsView.swift
+++ b/LDKNodeMonday/View/Settings/SettingsView.swift
@@ -166,7 +166,7 @@ struct SettingsView: View {
     #Preview {
         SettingsView(
             viewModel: .init(
-                walletClient: .constant(WalletClient(keyClient: KeyClient.mock)),
+                walletClient: .constant(WalletClient(appMode: AppMode.mock)),
                 lightningClient: .mock
             )
 


### PR DESCRIPTION
This PR updates the way balances are shown.
A tappable view switches between the following states with primary and secondary values:

- USD + total sats
- USD + BTC
- BTC + USD
- Total sats + unit label
- Onchain sats + unit label
- Lightning sats + unit label

https://github.com/user-attachments/assets/1ef4c112-507b-4b0d-8176-a739a3cdc2e7

Other changes:

- Refactor BitcoinViewModel to use BalanceDetails (now exposed from LightningNodeClient) instead of multiple calls
- Refactor BitcoinViewModel with a convenience update() function to use in BitcoinView
- Add an overall AppMode(.live or .mock) so that we can switch in one place
- Mock values for BalanceDetails
- Mock values for transaction amounts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified balance details now display a consolidated view of on-chain and Lightning funds.
  - An interactive balance toggle lets users switch between different balance presentations for a personalized experience.
  - New functionality to asynchronously retrieve balance details from the Lightning node.

- **Refactor**
  - Enhanced wallet configuration with adjustable modes for live and mock scenarios, ensuring consistent operational performance across the app.
  - Streamlined balance management logic for improved efficiency and clarity in balance retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->