### PR TITLE
fix: #174 zero amount when pasting

### DIFF
--- a/LDKNodeMonday/View/Home/Send/SendScanAddressView.swift
+++ b/LDKNodeMonday/View/Home/Send/SendScanAddressView.swift
@@ -92,6 +92,11 @@ extension SendScanAddressView {
 
                 withAnimation {
                     viewModel.sendViewState = .reviewPayment
+                    if viewModel.amountSat == 0 {
+                        viewModel.sendViewState = .manualEntry
+                    } else {
+                        viewModel.sendViewState = .reviewPayment
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
This fixes #174 and shows the manual entry screen if a valid onchain address is pasted but amount is 0.
From the manual entry screen the user can add an amount and see the pasted address.