### PR TITLE
fix: don't clear amount on scan

### DIFF
--- a/LDKNodeMonday/View/Home/Send/SendScanAddressView.swift
+++ b/LDKNodeMonday/View/Home/Send/SendScanAddressView.swift
@@ -58,7 +58,7 @@ extension SendScanAddressView {
                 isShowingAlert = true
             } else {
                 viewModel.address = extractedPaymentAddress?.address ?? ""
-                viewModel.amountSat = extractedAmount
+                viewModel.amountSat = extractedAmount != 0 ? extractedAmount : viewModel.amountSat
                 viewModel.paymentAddress = extractedPaymentAddress
 
                 withAnimation {


### PR DESCRIPTION
This PR fixes #181 

If an amount is set before scanning a QR that contains 0, it is no longer cleared.