### PR TITLE
fix: paymentslistview loading order

### DIFF
--- a/LDKNodeMonday/View/Home/Payments/PaymentsListView.swift
+++ b/LDKNodeMonday/View/Home/Payments/PaymentsListView.swift
@@ -18,6 +18,7 @@ struct PaymentsListView: View {
     @Binding var displayBalanceType: DisplayBalanceType
     var price: Double
     @State private var selectedPayment: PaymentDetails?
+    @State private var hasLoaded = false
 
     var sections: [PaymentSection] {
         orderedStatuses.compactMap { status -> PaymentSection? in
@@ -38,7 +39,11 @@ struct PaymentsListView: View {
     var body: some View {
         List {
             Section {
-                if payments.isEmpty {
+                if !hasLoaded {
+                    EmptyView()
+                        .frame(maxWidth: .infinity, minHeight: 400)
+                        .listRowSeparator(.hidden)
+                } else if payments.isEmpty {
                     VStack(spacing: 20) {
                         Text("No activity, yet.\nGo get some bitcoin!")
                             .font(.body)
@@ -90,6 +95,14 @@ struct PaymentsListView: View {
         }
         .listStyle(.plain)
         .padding(.horizontal)
+        .onAppear {
+            DispatchQueue.main.async {
+                hasLoaded = true
+            }
+        }
+        .onChange(of: payments) {
+            hasLoaded = true
+        }
         .sheet(item: $selectedPayment) { paymentDetail in
             PaymentDetailView(
                 payment: paymentDetail,


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Would quickly show `isEmpty` related views before loading payments, now it won't do that.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I have formatted my code with [swift-format](https://github.com/apple/swift-format) per `.swift-format` [file](https://github.com/reez/BDKSwiftExampleWallet/blob/main/.swift-format)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
