### PR TITLE
feat: lsp persistence across app launches

### DIFF
--- a/LDKNodeMonday/App/WalletClient.swift
+++ b/LDKNodeMonday/App/WalletClient.swift
@@ -52,7 +52,7 @@ public class WalletClient {
 
     func start() async {
         var backupInfo: BackupInfo?
-        backupInfo = try? KeyClient.live.getBackupInfo()
+        backupInfo = try? self.keyClient.getBackupInfo()
 
         if backupInfo != nil {
             do {


### PR DESCRIPTION
Fix WalletClient to load saved LSP from keychain on startup. Resolves issue where LSP selection reverted to default after restart.

The fix is in WalletClient.start() which now loads the persisted LSP selection from KeyService on app startup.

<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I have formatted my code with [swift-format](https://github.com/apple/swift-format) per `.swift-format` [file](https://github.com/reez/BDKSwiftExampleWallet/blob/main/.swift-format)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
