### PR TITLE
feat: Bip 177 notation

### DIFF
--- a/LDKNodeMonday/Extensions/UInt64+Extensions.swift
+++ b/LDKNodeMonday/Extensions/UInt64+Extensions.swift
@@ -56,6 +56,29 @@ extension UInt64 {
 
 }
 
+extension UInt64 {
+    private var numberFormatter: NumberFormatter {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.usesGroupingSeparator = true
+        numberFormatter.groupingSeparator = ","
+        numberFormatter.generatesDecimalNumbers = false
+        
+        return numberFormatter
+    }
+    
+    func formattedBip177() -> String {
+        if self != .zero && self >= 1_000_000 && self % 1_000_000 == .zero {
+            return "\(self / 1_000_000)M"
+            
+        } else if self != .zero && self % 1_000 == 0 {
+            return "\(self / 1_000)K"
+        }
+        
+        return numberFormatter.string(from: NSNumber(value: self)) ?? "0"
+    }
+}
+
 public enum BitcoinFormatting {
     case satscomma
     case truncated

--- a/LDKNodeMonday/View/Home/BitcoinView.swift
+++ b/LDKNodeMonday/View/Home/BitcoinView.swift
@@ -160,6 +160,12 @@ struct BalanceHeader: View {
             return viewModel.balances.totalLightningBalanceSats.formatted(
                 .number.notation(.automatic)
             )
+        case .totalBip177:
+            return "₿" + viewModel.unifiedBalance.formattedBip177()
+        case .onchainBip177:
+            return "₿" + viewModel.balances.totalOnchainBalanceSats.formattedBip177()
+        case .lightningBip177:
+            return "₿" + viewModel.balances.totalLightningBalanceSats.formattedBip177()
         }
     }
 
@@ -171,23 +177,22 @@ struct BalanceHeader: View {
             return "₿" + viewModel.unifiedBalance.formattedSatsAsBtc()
         case .btcFiat:
             return viewModel.totalUSDValue
-        case .totalSats:
+        case .totalSats, .totalBip177:
             return "Total"
-        case .onchainSats:
+        case .onchainSats, .onchainBip177:
             return "Onchain"
-        case .lightningSats:
+        case .lightningSats, .lightningBip177:
             return "Lightning"
+
         }
     }
 
     var unitValue: String {
         switch displayBalanceType {
-        case .fiatBtc:
-            return ""
-        case .btcFiat:
-            return ""
-        default:
+        case .totalSats, .onchainSats, .lightningSats:
             return "sats"
+        default:
+            return ""
         }
     }
 }
@@ -312,6 +317,9 @@ public enum DisplayBalanceType: String {
     case totalSats
     case onchainSats
     case lightningSats
+    case onchainBip177
+    case lightningBip177
+    case totalBip177
 }
 
 extension DisplayBalanceType {
@@ -328,6 +336,12 @@ extension DisplayBalanceType {
         case .onchainSats:
             self = .lightningSats
         case .lightningSats:
+            self = .totalBip177
+        case .totalBip177:
+            self = .onchainBip177
+        case .onchainBip177:
+            self = .lightningBip177
+        case .lightningBip177:
             self = .fiatSats
         }
     }


### PR DESCRIPTION
### Description

This PR added ₿-only format on balance screen view and resolve the [issue](https://github.com/reez/Monday/issues/217)

Reference
https://bitcoin.design/guide/designing-products/units-and-symbols/#sample-mockups

### Screens
<img width="400" height="867" alt="Simulator Screenshot - iPhone 15 Pro Max - 2025-07-17 at 11 38 02" src="https://github.com/user-attachments/assets/16a78d01-bb8d-4bfa-ac18-50e49b70e596" />
<img width="400" height="867" alt="Simulator Screenshot - iPhone 15 Pro Max - 2025-07-17 at 11 38 04" src="https://github.com/user-attachments/assets/671c690b-7054-4c5d-b672-5456576b5203" />
<img width="400" height="867" alt="Simulator Screenshot - iPhone 15 Pro Max - 2025-07-17 at 11 38 06" src="https://github.com/user-attachments/assets/a8c119d3-405c-46e3-aa45-468d5c3ed33b" />


### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I have formatted my code with [swift-format](https://github.com/apple/swift-format) per `.swift-format` [file](https://github.com/reez/BDKSwiftExampleWallet/blob/main/.swift-format)

#### New Features:

* [X] I've added tests for the new feature
* [ ] ~~I've added docs for the new feature~~
* [X] UI changes tested on small, medium, and large devices to ensure layout consistency