### PR TITLE
fix: rebuild node service on restart and persist lsp selection

### DIFF
--- a/LDKNodeMonday/App/WalletClient.swift
+++ b/LDKNodeMonday/App/WalletClient.swift
@@ -105,7 +105,11 @@ public class WalletClient {
                     self.appMode = .mock
                     self.keyClient = .mock
                     self.lightningClient = .mock
-                case .live, @unknown default:
+                case .live:
+                    self.appMode = .live
+                    self.keyClient = .live
+                    self.lightningClient = .live
+                @unknown default:
                     self.appMode = .live
                     self.keyClient = .live
                     self.lightningClient = .live
@@ -116,7 +120,9 @@ public class WalletClient {
             case .mock:
                 try LightningNodeService.stopAndReleaseShared()
             case .live:
-                try LightningNodeService.rebuildShared(keyService: self.keyClient)
+                _ = try LightningNodeService.rebuildShared(keyService: self.keyClient)
+            @unknown default:
+                _ = try LightningNodeService.rebuildShared(keyService: self.keyClient)
             }
 
             try await lightningClient.start()

--- a/LDKNodeMonday/App/WalletClient.swift
+++ b/LDKNodeMonday/App/WalletClient.swift
@@ -96,27 +96,38 @@ public class WalletClient {
         lsp: LightningServiceProvider? = nil
     ) async {
         do {
+            let targetMode = appMode ?? .live
+
             await MainActor.run {
                 self.appState = .loading
-                switch appMode {
+                switch targetMode {
                 case .mock:
                     self.appMode = .mock
                     self.keyClient = .mock
                     self.lightningClient = .mock
-                default:
+                case .live, @unknown default:
                     self.appMode = .live
                     self.keyClient = .live
                     self.lightningClient = .live
                 }
             }
-            try await lightningClient.restart()
+
+            switch targetMode {
+            case .mock:
+                try LightningNodeService.stopAndReleaseShared()
+            case .live:
+                try LightningNodeService.rebuildShared(keyService: self.keyClient)
+            }
+
+            try await lightningClient.start()
             lightningClient.listenForEvents()
+
             await MainActor.run {
                 self.network = newNetwork
                 self.server = newServer
                 self.appState = .wallet
 
-                if let lsp = lsp {
+                if let lsp {
                     self.lsp = lsp
                 }
             }

--- a/LDKNodeMonday/Service/KeyService/KeyService.swift
+++ b/LDKNodeMonday/Service/KeyService/KeyService.swift
@@ -46,7 +46,8 @@ extension KeyService {
         let newBackupInfo = BackupInfo(
             mnemonic: currentBackupInfo.mnemonic,
             networkString: networkString,
-            serverURL: currentBackupInfo.serverURL
+            serverURL: currentBackupInfo.serverURL,
+            lspString: currentBackupInfo.lspNodeId
         )
         try self.saveBackupInfo(backupInfo: newBackupInfo)
     }
@@ -65,7 +66,8 @@ extension KeyService {
         let newBackupInfo = BackupInfo(
             mnemonic: currentBackupInfo.mnemonic,
             networkString: currentBackupInfo.networkString,
-            serverURL: url
+            serverURL: url,
+            lspString: currentBackupInfo.lspNodeId
         )
         try self.saveBackupInfo(backupInfo: newBackupInfo)
     }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Reworked the restart flow so changing networks/servers (or toggling live/mock) now rebuilds the Lightning node instead of reusing the previous config. 

The client switches app mode, stops/releases any existing node, constructs a fresh service, and starts it before returning to the wallet view

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I have formatted my code with [swift-format](https://github.com/apple/swift-format) per `.swift-format` [file](https://github.com/reez/BDKSwiftExampleWallet/blob/main/.swift-format)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
